### PR TITLE
Add 2captcha softId

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,8 @@ try {
     // captcha is not solved so far
 }
 ```
+
+<!-- Shared links -->
 [2Captcha]: https://2captcha.com/
 [2captcha sofware catalog]: https://2captcha.com/software
 [pingback settings]: https://2captcha.com/setting/pingback

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The easiest way to quickly integrate [2Captcha] captcha solving service into you
   - [report](#report)
 - [Proxies](#proxies)
 - [Error handling](#error-handling)
+- [Useful links](#useful-links)
 
 
 ## Installation
@@ -291,9 +292,12 @@ try {
     // captcha is not solved so far
 }
 ```
-[2Captcha]: https://2captcha.com/
-[2captcha sofware catalog]: https://2captcha.com/software
-[pingback settings]: https://2captcha.com/setting/pingback
-[post options]: https://2captcha.com/2captcha-api#normal_post
-[list of supported languages]: https://2captcha.com/2captcha-api#language
-[examples directory]: /examples
+
+## Useful links
+
+- [2Captcha](https://2captcha.com/)
+- [2captcha sofware catalog](https://2captcha.com/software)
+- [Pingback settings](https://2captcha.com/setting/pingback)
+- [Post options](https://2captcha.com/2captcha-api#normal_post)
+- [List of supported languages](https://2captcha.com/2captcha-api#language)
+- [Examples directory](./examples)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ The easiest way to quickly integrate [2Captcha] captcha solving service into you
   - [report](#report)
 - [Proxies](#proxies)
 - [Error handling](#error-handling)
-- [Useful links](#useful-links)
 
 
 ## Installation
@@ -292,12 +291,9 @@ try {
     // captcha is not solved so far
 }
 ```
-
-## Useful links
-
-- [2Captcha](https://2captcha.com/)
-- [2captcha sofware catalog](https://2captcha.com/software)
-- [Pingback settings](https://2captcha.com/setting/pingback)
-- [Post options](https://2captcha.com/2captcha-api#normal_post)
-- [List of supported languages](https://2captcha.com/2captcha-api#language)
-- [Examples directory](./examples)
+[2Captcha]: https://2captcha.com/
+[2captcha sofware catalog]: https://2captcha.com/software
+[pingback settings]: https://2captcha.com/setting/pingback
+[post options]: https://2captcha.com/2captcha-api#normal_post
+[list of supported languages]: https://2captcha.com/2captcha-api#language
+[examples directory]: /examples

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The easiest way to quickly integrate [2Captcha] captcha solving service into you
   - [send / getResult](#send--getresult)
   - [balance](#balance)
   - [report](#report)
+- [Proxies](#proxies)
 - [Error handling](#error-handling)
 
 
@@ -257,6 +258,22 @@ Use this method to report good or bad captcha answer.
 ```php
 $solver->report($id, true); // captcha solved correctly
 $solver->report($id, false); // captcha solved incorrectly
+```
+## Proxies
+You can pass your proxy as an additional argument for methods: recaptcha, funcaptcha, geetest, geetest v4, hcaptcha, keycaptcha, capy puzzle, lemin, turnstile, amazon waf and etc. The proxy will be forwarded to the API to solve the captcha.
+
+We have our own proxies that we can offer you. [Buy residential proxies](https://2captcha.com/proxy/residential-proxies) for avoid restrictions and blocks. [Quick start](https://2captcha.com/proxy?openAddTrafficModal=true).
+
+Example solving reCAPTCHA V2 using proxy:
+```php
+$result = $solver->recaptcha([
+    'sitekey'   => '6Le-wvkSVVABCPBMRTvw0Q4Muexq1bi0DJwx_mJ-',
+    'url'       => 'https://mysite.com/page/with/recaptcha',
+    'proxy'     => [
+        'type' => 'HTTPS',
+        'uri'  => 'login:password@IP_address:PORT',
+    ],
+]);
 ```
 
 ## Error handling

--- a/src/TwoCaptcha.php
+++ b/src/TwoCaptcha.php
@@ -34,7 +34,7 @@ class TwoCaptcha
      *
      * @integer
      */
-    private $softId;
+    private $softId = 4585;
 
     /**
      * URL to which the result will be sent

--- a/tests/AmazonWafTest.php
+++ b/tests/AmazonWafTest.php
@@ -26,7 +26,8 @@ class AmazonWafTest extends AbstractWrapperTestCase
             'iv'         => 'test_iv',
             'context'    => 'test_context',
             'proxy'      => 'username:str0ngP@$$W0rd@1.2.3.4:4321',
-            'proxytype'  => 'HTTPS'                 
+            'proxytype'  => 'HTTPS',
+            'soft_id'    => '4585',
         ];
 
         $this->checkIfCorrectParamsSendAndResultReturned([

--- a/tests/AudioTest.php
+++ b/tests/AudioTest.php
@@ -18,8 +18,9 @@ class AudioTest extends AbstractWrapperTestCase
         ];
 
         $sendParams = [
-            'method'           => 'audio',
-            'body' => base64_encode(file_get_contents($audio))
+            'method'  => 'audio',
+            'body'    => base64_encode(file_get_contents($audio)),
+            'soft_id' => '4585',
         ];
 
 
@@ -42,9 +43,10 @@ class AudioTest extends AbstractWrapperTestCase
         ];
 
         $sendParams = [
-            'method'           => 'audio',
-            'body' => base64_encode(file_get_contents($audio)),
-            'lang'   => 'ru'
+            'method'  => 'audio',
+            'body'    => base64_encode(file_get_contents($audio)),
+            'lang'    => 'ru',
+            'soft_id' => '4585',
         ];
 
 

--- a/tests/CanvasTest.php
+++ b/tests/CanvasTest.php
@@ -22,7 +22,7 @@ class CanvasTest extends AbstractWrapperTestCase
     {
         $this->checkIfCorrectParamsSendAndResultReturned([
             'params'     => ['file' => $this->captchaImg, 'hintText' => $this->hintText],
-            'sendParams' => ['method' => 'post', 'canvas' => 1, 'recaptcha' => 1, 'textinstructions' => $this->hintText],
+            'sendParams' => ['method' => 'post', 'canvas' => 1, 'recaptcha' => 1, 'textinstructions' => $this->hintText, 'soft_id' => '4585'],
             'sendFiles'  => ['file' => $this->captchaImg],
         ]);
     }
@@ -31,7 +31,7 @@ class CanvasTest extends AbstractWrapperTestCase
     {
         $this->checkIfCorrectParamsSendAndResultReturned([
             'params'     => ['base64' => '...', 'hintText' => $this->hintText],
-            'sendParams' => ['method' => 'base64', 'canvas' => 1, 'body' => '...', 'recaptcha' => 1, 'textinstructions' => $this->hintText],
+            'sendParams' => ['method' => 'base64', 'canvas' => 1, 'body' => '...', 'recaptcha' => 1, 'textinstructions' => $this->hintText, 'soft_id' => '4585'],
             'sendFiles'  => [],
         ]);
     }
@@ -57,6 +57,7 @@ class CanvasTest extends AbstractWrapperTestCase
             'lang'             => 'en',
             'recaptcha'        => 1,
             'textinstructions' => $this->hintText,
+            'soft_id'          => '4585',
         ];
 
         $sendFiles = [

--- a/tests/CapyTest.php
+++ b/tests/CapyTest.php
@@ -17,6 +17,7 @@ class CapyTest extends AbstractWrapperTestCase
             'method'     => 'capy',
             'captchakey' => 'PUZZLE_Abc1dEFghIJKLM2no34P56q7rStu8v',
             'pageurl'    => 'http://mysite.com/',
+            'soft_id'    => '4585',
         ];
 
         $this->checkIfCorrectParamsSendAndResultReturned([

--- a/tests/CoordinatesTest.php
+++ b/tests/CoordinatesTest.php
@@ -12,7 +12,7 @@ class CoordinatesTest extends AbstractWrapperTestCase
     {
         $this->checkIfCorrectParamsSendAndResultReturned([
             'params'     => $this->captchaImg,
-            'sendParams' => ['method' => 'post', 'coordinatescaptcha' => 1],
+            'sendParams' => ['method' => 'post', 'coordinatescaptcha' => 1, 'soft_id' => '4585'],
             'sendFiles'  => ['file' => $this->captchaImg],
         ]);
     }
@@ -21,7 +21,7 @@ class CoordinatesTest extends AbstractWrapperTestCase
     {
         $this->checkIfCorrectParamsSendAndResultReturned([
             'params'     => ['file' => $this->captchaImg],
-            'sendParams' => ['method' => 'post', 'coordinatescaptcha' => 1],
+            'sendParams' => ['method' => 'post', 'coordinatescaptcha' => 1,'soft_id' => '4585'],
             'sendFiles'  => ['file' => $this->captchaImg],
         ]);
     }
@@ -30,7 +30,7 @@ class CoordinatesTest extends AbstractWrapperTestCase
     {
         $this->checkIfCorrectParamsSendAndResultReturned([
             'params'     => ['base64' => '...'],
-            'sendParams' => ['method' => 'base64', 'coordinatescaptcha' => 1, 'body' => '...'],
+            'sendParams' => ['method' => 'base64', 'coordinatescaptcha' => 1, 'body' => '...','soft_id' => '4585'],
             'sendFiles'  => [],
         ]);
     }
@@ -51,6 +51,7 @@ class CoordinatesTest extends AbstractWrapperTestCase
             'coordinatescaptcha' => 1,
             'lang'               => 'en',
             'textinstructions'   => 'Select all images with an Orange',
+            'soft_id'            => '4585',
         ];
 
         $sendFiles = [

--- a/tests/FunCaptchaTest.php
+++ b/tests/FunCaptchaTest.php
@@ -31,8 +31,9 @@ class FunCaptchaTest extends AbstractWrapperTestCase
             'data'      => [
                 'anyKey' => 'anyStringValue',
             ],
-            'proxy'                  => 'username:str0ngP@$$W0rd@1.2.3.4:4321',
-            'proxytype'              => 'HTTPS'                  
+            'proxy'     => 'username:str0ngP@$$W0rd@1.2.3.4:4321',
+            'proxytype' => 'HTTPS',
+            'soft_id'   => '4585',
         ];
 
         $this->checkIfCorrectParamsSendAndResultReturned([

--- a/tests/GeeTest.php
+++ b/tests/GeeTest.php
@@ -25,8 +25,9 @@ class GeeTest extends AbstractWrapperTestCase
             'api_server' => 'api-na.geetest.com',
             'challenge'  => '69A21A01-CC7B-B9C6-0F9A-E7FA06677FFC',
             'pageurl'    => 'https://launches.endclothing.com/distil_r_captcha.html',
-            'proxy'     => 'username:str0ngP@$$W0rd@1.2.3.4:4321',
-            'proxytype' => 'HTTPS'                 
+            'proxy'      => 'username:str0ngP@$$W0rd@1.2.3.4:4321',
+            'proxytype'  => 'HTTPS',
+            'soft_id'    => '4585',
         ];
 
         $this->checkIfCorrectParamsSendAndResultReturned([

--- a/tests/GeeTestV4.php
+++ b/tests/GeeTestV4.php
@@ -22,9 +22,10 @@ class GeeTestV4 extends AbstractWrapperTestCase
             'method'     => 'geetest_v4',
             'api_server' => 'api-na.geetest.com',
             'pageurl'    => 'https://launches.endclothing.com/distil_r_captcha.html',
-            'captcha_id'=> '72bf15796d0b69c43867452fea615052',
-            'proxy'     => 'username:str0ngP@$$W0rd@1.2.3.4:4321',
-            'proxytype' => 'HTTPS'            
+            'captcha_id' => '72bf15796d0b69c43867452fea615052',
+            'proxy'      => 'username:str0ngP@$$W0rd@1.2.3.4:4321',
+            'proxytype'  => 'HTTPS',
+            'soft_id'    => '4585',
         ];
 
  

--- a/tests/GridTest.php
+++ b/tests/GridTest.php
@@ -12,7 +12,7 @@ class GridTest extends AbstractWrapperTestCase
     {
         $this->checkIfCorrectParamsSendAndResultReturned([
             'params'     => $this->captchaImg,
-            'sendParams' => ['method' => 'post'],
+            'sendParams' => ['method' => 'post','soft_id' => '4585'],
             'sendFiles'  => ['file' => $this->captchaImg],
         ]);
     }
@@ -21,7 +21,7 @@ class GridTest extends AbstractWrapperTestCase
     {
         $this->checkIfCorrectParamsSendAndResultReturned([
             'params'     => ['file' => $this->captchaImg],
-            'sendParams' => ['method' => 'post'],
+            'sendParams' => ['method' => 'post','soft_id' => '4585'],
             'sendFiles'  => ['file' => $this->captchaImg],
         ]);
     }
@@ -30,7 +30,7 @@ class GridTest extends AbstractWrapperTestCase
     {
         $this->checkIfCorrectParamsSendAndResultReturned([
             'params'     => ['base64' => '...'],
-            'sendParams' => ['method' => 'base64', 'body' => '...'],
+            'sendParams' => ['method' => 'base64', 'body' => '...','soft_id' => '4585'],
             'sendFiles'  => [],
         ]);
     }
@@ -58,6 +58,7 @@ class GridTest extends AbstractWrapperTestCase
             'can_no_answer'    => 0,
             'lang'             => 'en',
             'textinstructions' => 'Select all images with an Orange',
+            'soft_id'          => '4585',
         ];
 
         $sendFiles = [

--- a/tests/HCaptchaTest.php
+++ b/tests/HCaptchaTest.php
@@ -18,11 +18,12 @@ class HCaptchaTest extends AbstractWrapperTestCase
         ];
 
         $sendParams = [
-            'method'  => 'hcaptcha',
-            'sitekey' => 'f1ab2cdefa3456789012345b6c78d90e',
-            'pageurl' => 'https://www.site.com/page/',
+            'method'    => 'hcaptcha',
+            'sitekey'   => 'f1ab2cdefa3456789012345b6c78d90e',
+            'pageurl'   => 'https://www.site.com/page/',
             'proxy'     => 'username:str0ngP@$$W0rd@1.2.3.4:4321',
-            'proxytype' => 'HTTPS'                  
+            'proxytype' => 'HTTPS',
+            'soft_id'   => '4585',
         ];
 
         $this->checkIfCorrectParamsSendAndResultReturned([

--- a/tests/KeyCaptchaTest.php
+++ b/tests/KeyCaptchaTest.php
@@ -28,7 +28,8 @@ class KeyCaptchaTest extends AbstractWrapperTestCase
             's_s_c_web_server_sign2' => '2ca3abe86d90c6142d5571db98af6714',
             'pageurl'                => 'https://www.keycaptcha.ru/demo-magnetic/',
             'proxy'                  => 'username:str0ngP@$$W0rd@1.2.3.4:4321',
-            'proxytype'              => 'HTTPS'              
+            'proxytype'              => 'HTTPS',
+            'soft_id'                => '4585',
         ];
 
         $this->checkIfCorrectParamsSendAndResultReturned([

--- a/tests/LeminTest.php
+++ b/tests/LeminTest.php
@@ -24,7 +24,8 @@ class LeminTest extends AbstractWrapperTestCase
             'api_server' => 'api.leminnow.com',
             'pageurl'    => 'http://sat2.aksigorta.com.tr',
             'proxy'      => 'username:str0ngP@$$W0rd@1.2.3.4:4321',
-            'proxytype'  => 'HTTPS'                 
+            'proxytype'  => 'HTTPS',
+            'soft_id'    => '4585',
         ];
 
         $this->checkIfCorrectParamsSendAndResultReturned([

--- a/tests/NormalTest.php
+++ b/tests/NormalTest.php
@@ -12,7 +12,7 @@ class NormalTest extends AbstractWrapperTestCase
     {
         $this->checkIfCorrectParamsSendAndResultReturned([
             'params'     => $this->captchaImg,
-            'sendParams' => ['method' => 'post'],
+            'sendParams' => ['method' => 'post','soft_id' => '4585'],
             'sendFiles'  => ['file' => $this->captchaImg],
         ]);
     }
@@ -21,7 +21,7 @@ class NormalTest extends AbstractWrapperTestCase
     {
         $this->checkIfCorrectParamsSendAndResultReturned([
             'params'     => ['file' => $this->captchaImg],
-            'sendParams' => ['method' => 'post'],
+            'sendParams' => ['method' => 'post','soft_id' => '4585'],
             'sendFiles'  => ['file' => $this->captchaImg],
         ]);
     }
@@ -30,7 +30,7 @@ class NormalTest extends AbstractWrapperTestCase
     {
         $this->checkIfCorrectParamsSendAndResultReturned([
             'params'     => ['base64' => '...'],
-            'sendParams' => ['method' => 'base64', 'body' => '...'],
+            'sendParams' => ['method' => 'base64', 'body' => '...','soft_id' => '4585'],
             'sendFiles'  => [],
         ]);
     }
@@ -62,6 +62,7 @@ class NormalTest extends AbstractWrapperTestCase
             'calc'             => 0,
             'lang'             => 'en',
             'textinstructions' => 'Type red symbols only',
+            'soft_id'          => '4585',
         ];
 
         $sendFiles = [

--- a/tests/ReCaptchaTest.php
+++ b/tests/ReCaptchaTest.php
@@ -26,7 +26,8 @@ class ReCaptchaTest extends AbstractWrapperTestCase
             'invisible' => 1,
             'action'    => 'verify',
             'proxy'     => 'username:str0ngP@$$W0rd@1.2.3.4:4321',
-            'proxytype' => 'HTTPS'
+            'proxytype' => 'HTTPS',
+            'soft_id'   => '4585',
         ];
 
         $this->checkIfCorrectParamsSendAndResultReturned([
@@ -53,6 +54,7 @@ class ReCaptchaTest extends AbstractWrapperTestCase
             'version'   => 'v3',
             'action'    => 'verify',
             'min_score' => 0.3,
+            'soft_id'   => '4585',
         ];
 
         $this->checkIfCorrectParamsSendAndResultReturned([

--- a/tests/RotateTest.php
+++ b/tests/RotateTest.php
@@ -23,7 +23,8 @@ class RotateTest extends AbstractWrapperTestCase
             'angle'            => 40,
             'lang'             => 'en',
             'textinstructions' => 'Put the images in the correct way up',
-            'body' => '...'
+            'body'             => '...',
+            'soft_id'          => '4585',
         ];
 
         $sendFiles = [

--- a/tests/TextTest.php
+++ b/tests/TextTest.php
@@ -10,7 +10,7 @@ class TextTest extends AbstractWrapperTestCase
     {
         $this->checkIfCorrectParamsSendAndResultReturned([
             'params'     => 'Today is monday?',
-            'sendParams' => ['method' => 'post', 'textcaptcha' => 'Today is monday?'],
+            'sendParams' => ['method' => 'post', 'textcaptcha' => 'Today is monday?','soft_id' => '4585'],
             'sendFiles'  => [],
         ]);
     }
@@ -19,7 +19,7 @@ class TextTest extends AbstractWrapperTestCase
     {
         $this->checkIfCorrectParamsSendAndResultReturned([
             'params'     => ['text' => 'Today is monday?'],
-            'sendParams' => ['method' => 'post', 'textcaptcha' => 'Today is monday?'],
+            'sendParams' => ['method' => 'post', 'textcaptcha' => 'Today is monday?','soft_id' => '4585'],
             'sendFiles'  => [],
         ]);
     }
@@ -28,7 +28,7 @@ class TextTest extends AbstractWrapperTestCase
     {
         $this->checkIfCorrectParamsSendAndResultReturned([
             'params'     => ['text' => 'Today is monday?', 'lang' => 'en'],
-            'sendParams' => ['method' => 'post', 'textcaptcha' => 'Today is monday?', 'lang' => 'en'],
+            'sendParams' => ['method' => 'post', 'textcaptcha' => 'Today is monday?', 'lang' => 'en','soft_id' => '4585'],
             'sendFiles'  => [],
         ]);
     }

--- a/tests/TurnstileTest.php
+++ b/tests/TurnstileTest.php
@@ -22,7 +22,8 @@ class TurnstileTest extends AbstractWrapperTestCase
             'sitekey'    => '0x4AAAAAAAChNiVJM_WtShFf',
             'pageurl'    => 'https://ace.fusionist.io',
             'proxy'      => 'username:str0ngP@$$W0rd@1.2.3.4:4321',
-            'proxytype'  => 'HTTPS'                 
+            'proxytype'  => 'HTTPS',
+            'soft_id'    => '4585',
         ];
 
         $this->checkIfCorrectParamsSendAndResultReturned([

--- a/tests/YandexTest.php
+++ b/tests/YandexTest.php
@@ -22,7 +22,8 @@ class YandexTest extends AbstractWrapperTestCase
             'sitekey'    => 'Y5Lh0tiycconMJGsFd3EbbuNKSp1yaZESUOIHfeV',
             'pageurl'    => 'https://rutube.ru',
             'proxy'      => 'username:str0ngP@$$W0rd@1.2.3.4:4321',
-            'proxytype'  => 'HTTPS'                 
+            'proxytype'  => 'HTTPS',
+            'soft_id'    => '4585',
         ];
 
         $this->checkIfCorrectParamsSendAndResultReturned([


### PR DESCRIPTION
### What is done:
- Add default `soft_id=4585`
- Update tests
- Add information about Proxy to README.md

Screenshot - Test execution completed successfully:
![image](https://github.com/2captcha/2captcha-php/assets/38065632/781a004c-5c71-4e0e-857e-827aab0b4309)
